### PR TITLE
missing proxydefaults step

### DIFF
--- a/README-v2.md
+++ b/README-v2.md
@@ -207,7 +207,13 @@ Note: The UI on Consul version 1.14 not yet recognize peers. Therefore apply int
 kubectl apply -f intentions.yaml --context $dc2
 ```
 
-18. Delete the counting service on dc1
+18. Apply the proxy-defaults on both datacenters to ensure data plane traffic goes via local mesh gateways 
+```
+kubectl apply -f proxydefaults.yaml --context $dc1
+kubectl apply -f proxydefaults.yaml --context $dc2
+```
+
+19. Delete the counting service on dc1
 ```
 kubectl delete -f counting.yaml --context $dc1
 ```


### PR DESCRIPTION
readmev2 is missing the step where we ask users to apply mesh-gateway local proxydefaults setting.